### PR TITLE
Correctly extract email field name on UserModel

### DIFF
--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -33,10 +33,11 @@ def get_or_create_from_id_token(client, id_token):
     )
 
     with transaction.atomic():
-        user, _ = get_user_model().objects.update_or_create(
+        UserModel = get_user_model()
+        user, _ = UserModel.objects.update_or_create(
             username=id_token_object['sub'],
             defaults={
-                'email': id_token_object.get('email', ''),
+                UserModel.get_email_field_name(): id_token_object.get('email', ''),
                 'first_name': id_token_object.get('given_name', ''),
                 'last_name': id_token_object.get('family_name', '')
             }
@@ -107,10 +108,11 @@ def _update_or_create(client, token_response, initiate_time):
         token=token_response['access_token'])
 
     with transaction.atomic():
-        user, _ = get_user_model().objects.update_or_create(
+        UserModel = get_user_model()
+        user, _ = UserModel.objects.update_or_create(
             username=id_token_object['sub'],
             defaults={
-                'email': userinfo.get('email', ''),
+                UserModel.get_email_field_name(): userinfo.get('email', ''),
                 'first_name': userinfo.get('given_name', ''),
                 'last_name': userinfo.get('family_name', '')
             }

--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -34,10 +34,11 @@ def get_or_create_from_id_token(client, id_token):
 
     with transaction.atomic():
         UserModel = get_user_model()
+        email_field_name = UserModel.get_email_field_name()
         user, _ = UserModel.objects.update_or_create(
             username=id_token_object['sub'],
             defaults={
-                UserModel.get_email_field_name(): id_token_object.get('email', ''),
+                email_field_name: id_token_object.get('email', ''),
                 'first_name': id_token_object.get('given_name', ''),
                 'last_name': id_token_object.get('family_name', '')
             }
@@ -109,10 +110,11 @@ def _update_or_create(client, token_response, initiate_time):
 
     with transaction.atomic():
         UserModel = get_user_model()
+        email_field_name = UserModel.get_email_field_name()
         user, _ = UserModel.objects.update_or_create(
             username=id_token_object['sub'],
             defaults={
-                UserModel.get_email_field_name(): userinfo.get('email', ''),
+                email_field_name: userinfo.get('email', ''),
                 'first_name': userinfo.get('given_name', ''),
                 'last_name': userinfo.get('family_name', '')
             }


### PR DESCRIPTION
When querying for models with customised email field, the query uses a hardcoded email field. This can be fixed by getting the user model to get the email field name as configured on the user class itself