### PR TITLE
Fix python version in example

### DIFF
--- a/example/resource-provider-api/Dockerfile
+++ b/example/resource-provider-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7-alpine
 
 RUN apk update \
    && apk add git openssl-dev libffi-dev python-dev build-base

--- a/example/resource-provider/Dockerfile
+++ b/example/resource-provider/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.7-alpine
 
 RUN apk update \
    && apk add git openssl-dev libffi-dev python-dev build-base


### PR DESCRIPTION
Currently, the resource-provider and resource-provider-api containers in the example use python:3-alpine which has recently been updated from 3.7 to 3.8.

This change caused the entrypoint-dev.sh script to crap out since it explicitly uses the python3.7 directory as the location of the certifi/cacert.pem file.

This PR fixes the python version to 3.7 to avoid this.