### PR TITLE
Support user models without username field

### DIFF
--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -101,13 +101,19 @@ def update_or_create_user_and_oidc_profile(client, id_token_object):
 
     with transaction.atomic():
         UserModel = get_user_model()
+
+        username_field = UserModel.USERNAME_FIELD
         email_field_name = UserModel.get_email_field_name()
-        user, _ = UserModel.objects.update_or_create(
-            username=id_token_object['sub'],
-            defaults={
-                email_field_name: id_token_object.get('email', ''),
-                'first_name': id_token_object.get('given_name', ''),
-                'last_name': id_token_object.get('family_name', '')
+
+        defaults = {
+            'first_name': id_token_object.get('given_name', ''),
+            'last_name': id_token_object.get('family_name', '')
+        }
+        if username_field != email_field_name:
+            defaults[email_field_name] = id_token_object.get('email', '')
+
+        user, _ = UserModel.objects.update_or_create(defaults=defaults, **{
+                username_field: id_token_object['sub']
             }
         )
 


### PR DESCRIPTION
A swappable user model may not have a dedicated `username` field and use (e.g.) the email field to identify users.
Don't assume that user models have that field and instead add it only if the fields declared by `USERNAME_FIELD` and `EMAIL_FIELD` differ when creating the local user record.