### PR TITLE
Respect preferred username

### DIFF
--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -113,7 +113,7 @@ def update_or_create_user_and_oidc_profile(client, id_token_object):
             defaults[email_field_name] = id_token_object.get('email', '')
 
         user, _ = UserModel.objects.update_or_create(defaults=defaults, **{
-                username_field: id_token_object['sub']
+                username_field: id_token_object.get('preferred_username', id_token_object['sub'])
             }
         )
 

--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -101,13 +101,19 @@ def update_or_create_user_and_oidc_profile(client, id_token_object):
 
     with transaction.atomic():
         UserModel = get_user_model()
+
+        username_field = UserModel.USERNAME_FIELD
         email_field_name = UserModel.get_email_field_name()
-        user, _ = UserModel.objects.update_or_create(
-            username=id_token_object['sub'],
-            defaults={
-                email_field_name: id_token_object.get('email', ''),
-                'first_name': id_token_object.get('given_name', ''),
-                'last_name': id_token_object.get('family_name', '')
+
+        defaults = {
+            'first_name': id_token_object.get('given_name', ''),
+            'last_name': id_token_object.get('family_name', '')
+        }
+        if username_field != email_field_name:
+            defaults[email_field_name] = id_token_object.get('email', '')
+
+        user, _ = UserModel.objects.update_or_create(defaults=defaults, **{
+                username_field: id_token_object['sub']
             }
         )
 


### PR DESCRIPTION
Setting `id_token_object['sub']` as the username is fine for new users, but doesn't migrate existing user profiles softly after migrating to Keycloak.