### PR TITLE
Add support for keycloak>v4 & Django 4.1.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,14 @@ Release Notes
 
 **unreleased**
 
+**v0.2.0**
+
+* Added support for keycloak > v4 & Django 4.1.1 (should be Django > v2.0)
+* Fixed issues
+    * https://github.com/Peter-Slump/django-keycloak/issues/57
+    * https://github.com/oauth2-proxy/oauth2-proxy/issues/1448
+* Updated steps at documentation to fix issue https://github.com/Peter-Slump/django-keycloak/issues/18.
+
 **v0.1.2-dev**
 
 **v0.1.1**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = u'2018, Peter Slump'
 author = u'Peter Slump'
 
 # The short X.Y version
-version = u''
+version = u'0.2.0'
 # The full version, including alpha/beta/rc tags
-release = u'0.1.2-dev'
+release = u'0.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/scenario/initial_setup.rst
+++ b/docs/scenario/initial_setup.rst
@@ -37,6 +37,25 @@ After you have added the realm please make sure to run te following actions:
     * :ref:`refresh_certificates`
     * :ref:`synchronize_permissions` (when using the permission system)
 
+
+Configure audience in Keycloak
+==============================
+* Goto to the "Client Scopes" menu
+    * Add Client scope 'my-app-scope'
+    * Within the settings of the 'my-app-scope' goto Mappers tab
+        * Create Protocol Mapper 'my-app-audience'
+            * Name: my-app-audience
+            * Choose Mapper type: Audience
+            * Included Client Audience: my-app
+            * Add to access token: on
+* Configure client my-app in the "Clients" menu
+    * Client Scopes tab in my-app settings
+    * Add available client scopes "my-app-scope" to assigned default client scopes
+
+References:
+    * `Client Scopes <https://www.keycloak.org/docs/latest/server_admin/#_client_scopes>`
+    * `Audience <https://www.keycloak.org/docs/latest/server_admin/#_audience_hardcoded>`
+
 Tools
 =====
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2-dev
+current_version = 0.2.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-VERSION = '0.1.2-dev'
+VERSION = '0.2.0'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
@@ -31,8 +31,8 @@ setup(
         'python-keycloak-client',
     ],
     install_requires=[
-        'python-keycloak-client>=0.2.2',
-        'Django>=1.11',
+        'python-keycloak-client>=0.3.0',
+        'Django>=2.0',
     ],
     tests_require=[
         'pytest-django',

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=Peter-Slump_django-keycloak
 sonar.organization=peter-slump-github
 sonar.projectName=Django Keycloak
-sonar.projectVersion=0.1.2-dev
+sonar.projectVersion=0.2.0
 
 # =====================================================
 #   Meta-data for the project

--- a/src/django_keycloak/services/oidc_profile.py
+++ b/src/django_keycloak/services/oidc_profile.py
@@ -103,7 +103,7 @@ def update_or_create_user_and_oidc_profile(client, id_token_object):
         UserModel = get_user_model()
         email_field_name = UserModel.get_email_field_name()
         user, _ = UserModel.objects.update_or_create(
-            username=id_token_object['sub'],
+            username=id_token_object['preferred_username'], # modified to map with the username
             defaults={
                 email_field_name: id_token_object.get('email', ''),
                 'first_name': id_token_object.get('given_name', ''),
@@ -166,7 +166,7 @@ def update_or_create_from_code(code, client, redirect_uri):
         code=code, redirect_uri=redirect_uri)
 
     return _update_or_create(client=client, token_response=token_response,
-                             initiate_time=initiate_time)
+                              initiate_time=initiate_time)
 
 
 def update_or_create_from_password_credentials(username, password, client):
@@ -219,7 +219,8 @@ def _update_or_create(client, token_response, initiate_time):
         key=client.realm.certs,
         algorithms=client.openid_api_client.well_known[
             'id_token_signing_alg_values_supported'],
-        issuer=issuer
+        issuer=issuer,
+        access_token=token_response["access_token"], # modified to fix the issue https://github.com/Peter-Slump/django-keycloak/issues/57
     )
 
     oidc_profile = update_or_create_user_and_oidc_profile(

--- a/src/django_keycloak/urls.py
+++ b/src/django_keycloak/urls.py
@@ -13,15 +13,14 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
-
+from django.urls import re_path
 from django_keycloak import views
 
 urlpatterns = [
-    url(r'^login$', views.Login.as_view(), name='keycloak_login'),
-    url(r'^login-complete$', views.LoginComplete.as_view(),
+    re_path(r'^login$', views.Login.as_view(), name='keycloak_login'),
+    re_path(r'^login-complete$', views.LoginComplete.as_view(),
         name='keycloak_login_complete'),
-    url(r'^logout$', views.Logout.as_view(), name='keycloak_logout'),
-    url(r'^session-iframe', views.SessionIframe.as_view(),
+    re_path(r'^logout$', views.Logout.as_view(), name='keycloak_logout'),
+    re_path(r'^session-iframe', views.SessionIframe.as_view(),
         name='keycloak_session_iframe')
 ]

--- a/src/django_keycloak/views.py
+++ b/src/django_keycloak/views.py
@@ -46,7 +46,7 @@ class Login(RedirectView):
         authorization_url = self.request.realm.client.openid_api_client\
             .authorization_url(
                 redirect_uri=nonce.redirect_uri,
-                scope='openid given_name family_name email',
+                scope='openid profile email', # modified from 'openid given_name family_name email' to fix invaild scopes, ref issue https://github.com/oauth2-proxy/oauth2-proxy/issues/1448
                 state=str(nonce.state)
             )
 


### PR DESCRIPTION
* Added support for keycloak > v17 & Django 4.1.1 (should be Django > v2.0)
* Fixed issues
    * https://github.com/Peter-Slump/django-keycloak/issues/57
    * https://github.com/oauth2-proxy/oauth2-proxy/issues/1448
* Updated steps at documentation to fix issue https://github.com/Peter-Slump/django-keycloak/issues/18 based on the answer https://stackoverflow.com/questions/53550321/keycloak-gatekeeper-aud-claim-and-client-id-do-not-match/53627747#53627747
* This package depends on upgrade [PR](https://github.com/Peter-Slump/python-keycloak-client/pull/53) for KC > v17
