### PR TITLE
Updated django.conf.urls reference to django.urls for Django>4.0

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -83,7 +83,7 @@ add the middleware, configure the urls and point to the correct login page.
     urlpatterns = [
         ...
 
-        url(r'^keycloak/', include('django_keycloak.urls')),
+        re_path(r'^keycloak/', include('django_keycloak.urls')),
     ]
 
 

--- a/example/resource-provider-api/myapp/urls.py
+++ b/example/resource-provider-api/myapp/urls.py
@@ -5,13 +5,13 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 from django.urls import re_path, include
 from django.contrib import admin

--- a/example/resource-provider-api/myapp/urls.py
+++ b/example/resource-provider-api/myapp/urls.py
@@ -10,17 +10,17 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
+    1. Import the include() function: from django.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.contrib import admin
 
 from myapp import views
 
 
 urlpatterns = [
-    url(r'^api/end-point$', views.api_end_point),
-    url(r'^api/authenticated-end-point$', views.authenticated_end_point),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^api/end-point$', views.api_end_point),
+    re_path(r'^api/authenticated-end-point$', views.authenticated_end_point),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/example/resource-provider/myapp/urls.py
+++ b/example/resource-provider/myapp/urls.py
@@ -10,19 +10,19 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
+    1. Import the include() function: from django.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import re_path, include
 from django.contrib import admin
 
 from myapp import views
 
 
 urlpatterns = [
-    url(r'^$', views.Home.as_view(), name='index'),
-    url(r'^secured$', views.Secured.as_view(), name='secured'),
-    url(r'^permission$', views.Permission.as_view(), name='permission'),
-    url(r'^keycloak/', include('django_keycloak.urls')),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^$', views.Home.as_view(), name='index'),
+    re_path(r'^secured$', views.Secured.as_view(), name='secured'),
+    re_path(r'^permission$', views.Permission.as_view(), name='permission'),
+    re_path(r'^keycloak/', include('django_keycloak.urls')),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/example/resource-provider/myapp/urls.py
+++ b/example/resource-provider/myapp/urls.py
@@ -5,13 +5,13 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 from django.urls import re_path, include
 from django.contrib import admin

--- a/src/django_keycloak/urls.py
+++ b/src/django_keycloak/urls.py
@@ -5,13 +5,13 @@ The `urlpatterns` list routes URLs to views. For more information please see:
 Examples:
 Function views
     1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', views.home, name='home')
 Class-based views
     1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+    2. Add a URL to urlpatterns:  re_path(r'^$', Home.as_view(), name='home')
 Including another URLconf
     1. Import the include() function: from django.urls import url, include
-    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+    2. Add a URL to urlpatterns:  re_path(r'^blog/', include('blog.urls'))
 """
 from django.urls import re_path
 

--- a/src/django_keycloak/urls.py
+++ b/src/django_keycloak/urls.py
@@ -10,18 +10,18 @@ Class-based views
     1. Add an import:  from other_app.views import Home
     2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
 Including another URLconf
-    1. Import the include() function: from django.conf.urls import url, include
+    1. Import the include() function: from django.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+from django.urls import re_path
 
 from django_keycloak import views
 
 urlpatterns = [
-    url(r'^login$', views.Login.as_view(), name='keycloak_login'),
-    url(r'^login-complete$', views.LoginComplete.as_view(),
+    re_path(r'^login$', views.Login.as_view(), name='keycloak_login'),
+    re_path(r'^login-complete$', views.LoginComplete.as_view(),
         name='keycloak_login_complete'),
-    url(r'^logout$', views.Logout.as_view(), name='keycloak_logout'),
-    url(r'^session-iframe', views.SessionIframe.as_view(),
+    re_path(r'^logout$', views.Logout.as_view(), name='keycloak_logout'),
+    re_path(r'^session-iframe', views.SessionIframe.as_view(),
         name='keycloak_session_iframe')
 ]


### PR DESCRIPTION
Django 4.0 removed django.conf from its library, replacing django.conf.urls.url for django.urls.re_path without damages. This is replacing the calls of url to use re_path to follow the new guidelines.